### PR TITLE
Make fog effects only apply below cloud level

### DIFF
--- a/src/main/java/supercoder79/ecotones/mixin/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/MixinBackgroundRenderer.java
@@ -3,6 +3,7 @@ package supercoder79.ecotones.mixin;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.BackgroundRenderer;
+import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -13,13 +14,14 @@ import supercoder79.ecotones.client.FogHandler;
 public class MixinBackgroundRenderer {
     @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;fogStart(F)V"))
     private static void applyEcotonesFancyFog(float start) {
+        MinecraftClient client = MinecraftClient.getInstance();
         if (ClientSidedServerData.isInEcotonesWorld) {
-            long time = MinecraftClient.getInstance().world.getTime();
+            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 128, 0, 4) / 4);
+
+            long time = client.world.getTime();
 
             // TODO: biome humidity
-
-
-            RenderSystem.fogStart(Math.min(start, (float) (start * FogHandler.multiplierFor(time))));
+            RenderSystem.fogStart(Math.min(start, (float) (start * FogHandler.multiplierFor(time))) * heightMultiplier);
         } else {
             RenderSystem.fogStart(start);
         }

--- a/src/main/java/supercoder79/ecotones/mixin/MixinSkyProperties.java
+++ b/src/main/java/supercoder79/ecotones/mixin/MixinSkyProperties.java
@@ -1,6 +1,8 @@
 package supercoder79.ecotones.mixin;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.SkyProperties;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,9 +15,11 @@ public class MixinSkyProperties {
     @Inject(method = "adjustFogColor", at = @At("RETURN"), cancellable = true)
     private void useEcotonesFancyFogColor(Vec3d color, float sunHeight, CallbackInfoReturnable<Vec3d> cir) {
         if (ClientSidedServerData.isInEcotonesWorld) {
+            MinecraftClient client = MinecraftClient.getInstance();
             if (sunHeight <= 0.0) {
+                double heightMultiplier = MathHelper.clamp(client.player.getY() - 128, 0, 4) / 4;
                 Vec3d adjustedColor = cir.getReturnValue();
-                cir.setReturnValue(adjustedColor.add(0.05, 0.025, 0.1));
+                cir.setReturnValue(adjustedColor.add(new Vec3d(0.05, 0.025, 0.1).multiply(heightMultiplier)));
             }
         }
     }


### PR DESCRIPTION
Fog effects (thickness, color) clear away as you go above the clouds
![clouds_fog](https://user-images.githubusercontent.com/43485105/118041520-c2e7ce00-b327-11eb-9b9c-e336c15774b1.gif)
Transition is also smooth