### PR TITLE
Fix Compatibility Issues With Origins

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ loader_version=0.11.6
 fabric_version=0.37.0+1.17
 
 # Mod Properties
-mod_version = 0.8.0
+mod_version = 0.8.1
 maven_group = supercoder79
 archives_base_name = ecotones

--- a/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
@@ -13,31 +13,14 @@ import supercoder79.ecotones.client.FogHandler;
 
 @Mixin(BackgroundRenderer.class)
 public class MixinBackgroundRenderer {
-//    @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
-//    private static void applyEcotonesFancyFog(float start) {
-//        MinecraftClient client = MinecraftClient.getInstance();
-//        RenderSystem.setShaderFogStart(start);
-//
-//        if (ClientSidedServerData.isInEcotonesWorld) {
-//            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
-//
-//            long time = client.world.getLunarTime();
-//
-//            // TODO: biome humidity
-//            RenderSystem.setShaderFogStart(Math.min(start, (float) (start * FogHandler.multiplierFor(time)) * heightMultiplier));
-//        } else {
-//            RenderSystem.setShaderFogStart(start);
-//        }
-//    }
-    
     @ModifyArg(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
     private static float applyEcotonesFancyFog(float start) {
         if (ClientSidedServerData.isInEcotonesWorld) {
             MinecraftClient client = MinecraftClient.getInstance();
-    
+            
             assert client.player != null;
             float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
-    
+            
             assert client.world != null;
             long time = client.world.getLunarTime();
             

--- a/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import supercoder79.ecotones.client.ClientSidedServerData;
 import supercoder79.ecotones.client.FogHandler;
 
-@Mixin(value = BackgroundRenderer.class)
+@Mixin(BackgroundRenderer.class)
 public class MixinBackgroundRenderer {
 //    @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
 //    private static void applyEcotonesFancyFog(float start) {

--- a/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
@@ -1,13 +1,11 @@
 package supercoder79.ecotones.mixin.client;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.BackgroundRenderer;
 import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import supercoder79.ecotones.client.ClientSidedServerData;
 import supercoder79.ecotones.client.FogHandler;
 

--- a/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
@@ -11,20 +11,20 @@ import supercoder79.ecotones.client.FogHandler;
 
 @Mixin(BackgroundRenderer.class)
 public class MixinBackgroundRenderer {
-    @ModifyArg(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
-    private static float applyEcotonesFancyFog(float start) {
-        if (ClientSidedServerData.isInEcotonesWorld) {
-            MinecraftClient client = MinecraftClient.getInstance();
-            
-            assert client.player != null;
-            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
-            
-            assert client.world != null;
-            long time = client.world.getLunarTime();
-            
-            return Math.min(start, (float) (start * FogHandler.multiplierFor(time)) * heightMultiplier);
-        } else {
-            return start;
-        }
-    }
+//    @ModifyArg(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
+//    private static float applyEcotonesFancyFog(float start) {
+//        if (ClientSidedServerData.isInEcotonesWorld) {
+//            MinecraftClient client = MinecraftClient.getInstance();
+//
+//            assert client.player != null;
+//            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
+//
+//            assert client.world != null;
+//            long time = client.world.getLunarTime();
+//
+//            return Math.min(start, (float) (start * FogHandler.multiplierFor(time)) * heightMultiplier);
+//        } else {
+//            return start;
+//        }
+//    }
 }

--- a/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
+++ b/src/main/java/supercoder79/ecotones/mixin/client/MixinBackgroundRenderer.java
@@ -6,17 +6,18 @@ import net.minecraft.client.render.BackgroundRenderer;
 import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import supercoder79.ecotones.client.ClientSidedServerData;
 import supercoder79.ecotones.client.FogHandler;
 
-@Mixin(BackgroundRenderer.class)
+@Mixin(value = BackgroundRenderer.class)
 public class MixinBackgroundRenderer {
-    @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
-    private static void applyEcotonesFancyFog(float start) {
-        MinecraftClient client = MinecraftClient.getInstance();
-        RenderSystem.setShaderFogStart(start);
-
+//    @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
+//    private static void applyEcotonesFancyFog(float start) {
+//        MinecraftClient client = MinecraftClient.getInstance();
+//        RenderSystem.setShaderFogStart(start);
+//
 //        if (ClientSidedServerData.isInEcotonesWorld) {
 //            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
 //
@@ -27,5 +28,22 @@ public class MixinBackgroundRenderer {
 //        } else {
 //            RenderSystem.setShaderFogStart(start);
 //        }
+//    }
+    
+    @ModifyArg(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", ordinal = 1))
+    private static float applyEcotonesFancyFog(float start) {
+        if (ClientSidedServerData.isInEcotonesWorld) {
+            MinecraftClient client = MinecraftClient.getInstance();
+    
+            assert client.player != null;
+            float heightMultiplier = (float) (MathHelper.clamp(client.player.getY() - 124, 0, 8) / 8);
+    
+            assert client.world != null;
+            long time = client.world.getLunarTime();
+            
+            return Math.min(start, (float) (start * FogHandler.multiplierFor(time)) * heightMultiplier);
+        } else {
+            return start;
+        }
     }
 }


### PR DESCRIPTION
Ecotones was previously incompatible with Origins due to a Redirect mixin conflict.
```
[10:43:49] [Render thread/WARN]: @Redirect conflict. Skipping ecotones.mixins.json:client.MixinBackgroundRenderer
->@Redirect::applyEcotonesFancyFog(F)V with priority 1000, already redirected by apoli.mixins.json:BackgroundRendererMixin
->@Redirect::redirectFogStart(FLnet/minecraft/class_4184;Lnet/minecraft/class_758$class_4596;)V with priority 1000
```
Fixes #18