### PR TITLE
fix: fix duping blueberries

### DIFF
--- a/src/main/java/supercoder79/ecotones/blocks/BlueberryBushBlock.java
+++ b/src/main/java/supercoder79/ecotones/blocks/BlueberryBushBlock.java
@@ -143,6 +143,8 @@ public class BlueberryBushBlock extends PlantBlock implements Fertilizable {
         int baseCount = 1;
         int randomCount = 3;
 
+        if (state.get(AGE) < 2) return ImmutableList.of();
+
         ServerWorld world = builder.getWorld();
         ChunkGenerator generator = world.getChunkManager().getChunkGenerator();
 


### PR DESCRIPTION
This fixes https://github.com/jaskarth/ecotones/issues/39
New blueberries drop behaviour is similar to vanilla sweet berries where it doesn't drop anything if it's on 0 or 1 age stage.